### PR TITLE
Fix routing for React Router SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,18 @@ const PORTFOLIO_FRONT = 'your-portfolio.vercel.app';
 export default {
 	async fetch(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
 		// 受信 URL をコピーしてホスト名だけ後で差し替える
-		const target = new URL(request.url);
-		const path = target.pathname; // `/spam-checker/...` など
+               const target = new URL(request.url);
+               const path = target.pathname; // `/spam-checker/...` など
+
+               // React Router SSR assets are requested from the root (e.g. `/__manifest`)
+               if (path.startsWith('/__')) {
+                       target.hostname = SPAM_FRONTEND;
+                       target.protocol = 'https:';
+                       target.port = '';
+
+                       const spaReq = new Request(target.toString(), request);
+                       return fetch(spaReq);
+               }
 		// ❶ FastAPI backend ---------------------------------------------------
 		if (path.startsWith('/spam-checker/api')) {
 			target.hostname = BACKEND_API;


### PR DESCRIPTION
## Summary
- handle root-level SSR asset requests for the spam checker app

## Testing
- `npm test --silent` *(fails: `vitest` not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cbbc9981483328050545ec5e1b088